### PR TITLE
Add pinOrigin join option to adopt the real origin on connect

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@obsidion/bridge",
-  "version": "0.11.2",
+  "version": "0.12.1",
   "description": "Obsidion Bridge: A reliable end-to-end encrypted websocket bridge",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/bridge-connection.ts
+++ b/src/bridge-connection.ts
@@ -72,8 +72,6 @@ export class BridgeConnection {
   constructor(options: BridgeOptions) {
     this.role = options.role
     this.origin = options.origin
-    // With pinOrigin disabled, the expected origin is left unset here so it is
-    // adopted later from the origin-on-connect message instead
     const shouldPinOrigin = options.pinOrigin ?? true
     this._bridgeOrigin = shouldPinOrigin ? options.domain : undefined
     this.log = debug(`bridge:${this.role}`)

--- a/src/bridge-connection.ts
+++ b/src/bridge-connection.ts
@@ -72,7 +72,8 @@ export class BridgeConnection {
   constructor(options: BridgeOptions) {
     this.role = options.role
     this.origin = options.origin
-    // Without pinning, the origin stays unset until the server reports it on connect
+    // Disable pinning to let the app decide which origins to allow, instead of rejecting
+    // every origin that differs from the connection string
     const shouldPinOrigin = options.pinOrigin ?? true
     this._bridgeOrigin = shouldPinOrigin ? options.domain : undefined
     this.log = debug(`bridge:${this.role}`)

--- a/src/bridge-connection.ts
+++ b/src/bridge-connection.ts
@@ -72,6 +72,7 @@ export class BridgeConnection {
   constructor(options: BridgeOptions) {
     this.role = options.role
     this.origin = options.origin
+    // Without pinning, the origin stays unset until the server reports it on connect
     const shouldPinOrigin = options.pinOrigin ?? true
     this._bridgeOrigin = shouldPinOrigin ? options.domain : undefined
     this.log = debug(`bridge:${this.role}`)

--- a/src/bridge-connection.ts
+++ b/src/bridge-connection.ts
@@ -72,7 +72,11 @@ export class BridgeConnection {
   constructor(options: BridgeOptions) {
     this.role = options.role
     this.origin = options.origin
-    this._bridgeOrigin = options.domain
+    // The joiner pins the connection-string origin by default and rejects any
+    // mismatch. When pinOrigin is explicitly disabled, the expected origin is
+    // left unset so the real origin is adopted from the origin-on-connect report.
+    const shouldPinOrigin = options.pinOrigin ?? true
+    this._bridgeOrigin = shouldPinOrigin ? options.domain : undefined
     this.log = debug(`bridge:${this.role}`)
     this.bridgeId = options.bridgeId || generateRandomId(16)
     this.keyPair = options.keyPair

--- a/src/bridge-connection.ts
+++ b/src/bridge-connection.ts
@@ -72,8 +72,6 @@ export class BridgeConnection {
   constructor(options: BridgeOptions) {
     this.role = options.role
     this.origin = options.origin
-    // Disable pinning to let the app decide which origins to allow, instead of rejecting
-    // every origin that differs from the connection string
     const shouldPinOrigin = options.pinOrigin ?? true
     this._bridgeOrigin = shouldPinOrigin ? options.domain : undefined
     this.log = debug(`bridge:${this.role}`)

--- a/src/bridge-connection.ts
+++ b/src/bridge-connection.ts
@@ -72,9 +72,8 @@ export class BridgeConnection {
   constructor(options: BridgeOptions) {
     this.role = options.role
     this.origin = options.origin
-    // The joiner pins the connection-string origin by default and rejects any
-    // mismatch. When pinOrigin is explicitly disabled, the expected origin is
-    // left unset so the real origin is adopted from the origin-on-connect report.
+    // With pinOrigin disabled, the expected origin is left unset here so it is
+    // adopted later from the origin-on-connect message instead
     const shouldPinOrigin = options.pinOrigin ?? true
     this._bridgeOrigin = shouldPinOrigin ? options.domain : undefined
     this.log = debug(`bridge:${this.role}`)
@@ -767,21 +766,26 @@ export class BridgeConnection {
 
   /**
    * Get the bridge origin (the origin of the creator)
+   * Undefined for a joiner with pinOrigin disabled until the origin-on-connect message arrives
    */
-  public get bridgeOrigin(): string {
-    if (this.role === "creator") return this.origin!
-    else return this._bridgeOrigin!
+  public get bridgeOrigin(): string | undefined {
+    if (this.role === "creator") return this.origin
+    else return this._bridgeOrigin
   }
 
   /**
    * Get a connection string URI for joining the bridge
    */
   public get connectionString(): string {
+    const bridgeOrigin = this.bridgeOrigin
+    if (!bridgeOrigin) {
+      throw new Error("Bridge origin is not known yet, wait for the secure channel to be established")
+    }
     const oocParam = this.originOnConnect ? "&ooc" : ""
     if (this.role === "creator") {
-      return `obsidion:${this.getPublicKey()}?d=${this.bridgeOrigin!}&v=${PROTOCOL_VERSION}${oocParam}`
+      return `obsidion:${this.getPublicKey()}?d=${bridgeOrigin}&v=${PROTOCOL_VERSION}${oocParam}`
     } else {
-      return `obsidion:${this.getBridgeId()}?d=${this.bridgeOrigin!}&v=${PROTOCOL_VERSION}${oocParam}`
+      return `obsidion:${this.getBridgeId()}?d=${bridgeOrigin}&v=${PROTOCOL_VERSION}${oocParam}`
     }
   }
 

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -36,9 +36,6 @@ export interface JoinOptions {
   pingInterval?: number
   bridgeUrl?: string
   originOnConnect?: boolean
-  // Defaults to true. When false, the joiner does not pin the connection-string
-  // origin and instead adopts the real origin reported via origin-on-connect,
-  // leaving origin trust to the caller.
   pinOrigin?: boolean
 }
 
@@ -59,7 +56,8 @@ export interface BridgeInterface extends Disposable {
   isSecureChannelEstablished: () => boolean
   sendMessage: (method: string, params?: any) => Promise<boolean>
   connectionString: string
-  origin: string
+  // Undefined for a joiner with pinOrigin: false until the secure channel is established
+  origin: string | undefined
   bridgeId: string
   getPublicKey: () => string
   getRemotePublicKey: () => string
@@ -149,13 +147,9 @@ export class Bridge {
       isBridgeConnected: () => connection.isBridgeConnected(),
       isSecureChannelEstablished: () => connection.isSecureChannelEstablished(),
       sendMessage: (method, params) => connection.sendSecureMessage(method, params || {}),
-      connectionString: connection.connectionString!,
+      connectionString: connection.connectionString,
       bridgeId: connection.getBridgeId(),
-      // Live getter: with pinOrigin disabled the real origin is only known once
-      // the origin-on-connect report arrives, after this object is returned.
-      get origin() {
-        return connection.bridgeOrigin
-      },
+      origin: connection.bridgeOrigin,
       getKeyPair: () => connection.keyPair,
       getPublicKey: () => connection.getPublicKey(),
       // TODO: Deprecate close() and use cleanup() instead
@@ -191,6 +185,10 @@ export class Bridge {
 
     // Determine originOnConnect: use explicit option if provided, otherwise use value from connection string
     const originOnConnect = options.originOnConnect !== undefined ? options.originOnConnect : ooc
+
+    if (options.pinOrigin === false && (!originOnConnect || options.resume)) {
+      throw new Error("pinOrigin: false requires originOnConnect and cannot be combined with resume")
+    }
 
     // Create connection instance with joiner role and domain
     const connection = new BridgeConnection({
@@ -232,10 +230,10 @@ export class Bridge {
       isBridgeConnected: () => connection.isBridgeConnected(),
       isSecureChannelEstablished: () => connection.isSecureChannelEstablished(),
       sendMessage: (method, params) => connection.sendSecureMessage(method, params || {}),
-      connectionString: connection.connectionString!,
+      get connectionString() {
+        return connection.connectionString
+      },
       bridgeId: connection.getBridgeId(),
-      // Live getter: with pinOrigin disabled the real origin is only known once
-      // the origin-on-connect report arrives, after this object is returned.
       get origin() {
         return connection.bridgeOrigin
       },

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -36,6 +36,10 @@ export interface JoinOptions {
   pingInterval?: number
   bridgeUrl?: string
   originOnConnect?: boolean
+  // Defaults to true. When false, the joiner does not pin the connection-string
+  // origin and instead adopts the real origin reported via origin-on-connect,
+  // leaving origin trust to the caller.
+  pinOrigin?: boolean
 }
 
 /**
@@ -147,7 +151,11 @@ export class Bridge {
       sendMessage: (method, params) => connection.sendSecureMessage(method, params || {}),
       connectionString: connection.connectionString!,
       bridgeId: connection.getBridgeId(),
-      origin: connection.bridgeOrigin,
+      // Live getter: with pinOrigin disabled the real origin is only known once
+      // the origin-on-connect report arrives, after this object is returned.
+      get origin() {
+        return connection.bridgeOrigin
+      },
       getKeyPair: () => connection.keyPair,
       getPublicKey: () => connection.getPublicKey(),
       // TODO: Deprecate close() and use cleanup() instead
@@ -195,6 +203,7 @@ export class Bridge {
       pingInterval: options.pingInterval,
       bridgeUrl: options.bridgeUrl,
       originOnConnect,
+      pinOrigin: options.pinOrigin,
     })
 
     // Set remote public key
@@ -225,7 +234,11 @@ export class Bridge {
       sendMessage: (method, params) => connection.sendSecureMessage(method, params || {}),
       connectionString: connection.connectionString!,
       bridgeId: connection.getBridgeId(),
-      origin: connection.bridgeOrigin,
+      // Live getter: with pinOrigin disabled the real origin is only known once
+      // the origin-on-connect report arrives, after this object is returned.
+      get origin() {
+        return connection.bridgeOrigin
+      },
       getKeyPair: () => connection.keyPair,
       getPublicKey: () => connection.getPublicKey(),
       getRemotePublicKey: () => connection.getRemotePublicKey(),

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -56,7 +56,6 @@ export interface BridgeInterface extends Disposable {
   isSecureChannelEstablished: () => boolean
   sendMessage: (method: string, params?: any) => Promise<boolean>
   connectionString: string
-  // Undefined for a joiner with pinOrigin: false until the secure channel is established
   origin: string | undefined
   bridgeId: string
   getPublicKey: () => string

--- a/src/types.ts
+++ b/src/types.ts
@@ -100,4 +100,5 @@ export interface BridgeOptions {
   pingInterval?: number
   bridgeUrl?: string
   originOnConnect?: boolean
+  pinOrigin?: boolean
 }

--- a/tests/bridge.test.ts
+++ b/tests/bridge.test.ts
@@ -352,8 +352,6 @@ describe("Bridge", () => {
     await using creator = await Bridge.create({ ...CREATE_OPTIONS, origin: actualOrigin })
     await waitForCallback(creator.onConnect)
 
-    // The connection string claims a wrong origin, but with pinning disabled the
-    // joiner should adopt the creator's real origin instead of rejecting the mismatch
     const tamperedConnectionString = creator.connectionString.replace(actualOrigin, wrongOrigin)
 
     await using joiner = await Bridge.join(tamperedConnectionString, { ...JOIN_OPTIONS, pinOrigin: false })

--- a/tests/bridge.test.ts
+++ b/tests/bridge.test.ts
@@ -352,16 +352,37 @@ describe("Bridge", () => {
     await using creator = await Bridge.create({ ...CREATE_OPTIONS, origin: actualOrigin })
     await waitForCallback(creator.onConnect)
 
-    // The connection string claims a different origin, but the joiner opts out
-    // of pinning, so it should adopt the creator's real origin instead of failing.
+    // The connection string claims a wrong origin, but with pinning disabled the
+    // joiner should adopt the creator's real origin instead of rejecting the mismatch
     const tamperedConnectionString = creator.connectionString.replace(actualOrigin, wrongOrigin)
 
     await using joiner = await Bridge.join(tamperedConnectionString, { ...JOIN_OPTIONS, pinOrigin: false })
+
+    // The origin is unknown until the server reports it
+    expect(joiner.origin).toBeUndefined()
+    expect(() => joiner.connectionString).toThrow("Bridge origin is not known yet")
+
     await waitForCallback(joiner.onSecureChannelEstablished)
 
     expect(joiner.origin).toBe(actualOrigin)
+    expect(joiner.connectionString).toContain(`d=${actualOrigin}`)
     // @ts-expect-error private property
     expect(joiner.connection._originValidatedViaOoc).toBe(true)
+  })
+
+  test("should reject pinOrigin: false when no origin can be adopted", async () => {
+    await using creator = await Bridge.create(CREATE_OPTIONS)
+    await waitForCallback(creator.onConnect)
+
+    // Without originOnConnect the server never reports the origin, so there is nothing to adopt
+    await expect(
+      Bridge.join(creator.connectionString, { ...JOIN_OPTIONS, pinOrigin: false, originOnConnect: false })
+    ).rejects.toThrow("pinOrigin")
+
+    // A resumed session skips the origin report as well
+    await expect(
+      Bridge.join(creator.connectionString, { ...JOIN_OPTIONS, pinOrigin: false, resume: true, keyPair: keyPairMobile })
+    ).rejects.toThrow("pinOrigin")
   })
 
   test("should ignore unsolicited ooc messages", async () => {

--- a/tests/bridge.test.ts
+++ b/tests/bridge.test.ts
@@ -345,6 +345,25 @@ describe("Bridge", () => {
     expect(error).toContain(wrongOrigin)
   })
 
+  test("should adopt the real origin on connect when pinOrigin is false", async () => {
+    const actualOrigin = "https://actual-ooc-origin.com"
+    const wrongOrigin = "https://wrong-ooc-origin.com"
+
+    await using creator = await Bridge.create({ ...CREATE_OPTIONS, origin: actualOrigin })
+    await waitForCallback(creator.onConnect)
+
+    // The connection string claims a different origin, but the joiner opts out
+    // of pinning, so it should adopt the creator's real origin instead of failing.
+    const tamperedConnectionString = creator.connectionString.replace(actualOrigin, wrongOrigin)
+
+    await using joiner = await Bridge.join(tamperedConnectionString, { ...JOIN_OPTIONS, pinOrigin: false })
+    await waitForCallback(joiner.onSecureChannelEstablished)
+
+    expect(joiner.origin).toBe(actualOrigin)
+    // @ts-expect-error private property
+    expect(joiner.connection._originValidatedViaOoc).toBe(true)
+  })
+
   test("should ignore unsolicited ooc messages", async () => {
     const { BridgeConnection } = await import("../src/bridge-connection")
     const connection = new BridgeConnection({

--- a/tests/helpers/mock-websocket.ts
+++ b/tests/helpers/mock-websocket.ts
@@ -100,9 +100,8 @@ export class MockWebSocket {
       return
     }
 
-    // Ignore JSON RPC messages with method: 'replay'
-    // These are intended for the bridge server only and should not be broadcast and relayed to other clients
-    // TODO: Implement actual replay logic to mirror the bridge server's replay logic
+    // Replay requests are meant for the bridge server only, never for other clients
+    // TODO: Mirror the bridge server's replay logic in this mock
     if (parsed && parsed.method === "replay") {
       return
     }

--- a/tests/helpers/mock-websocket.ts
+++ b/tests/helpers/mock-websocket.ts
@@ -100,8 +100,9 @@ export class MockWebSocket {
       return
     }
 
-    // Replay requests are meant for the bridge server only, never for other clients
-    // TODO: Mirror the bridge server's replay logic in this mock
+    // Ignore JSON RPC messages with method: 'replay'
+    // These are intended for the bridge server only and should not be broadcast and relayed to other clients
+    // TODO: Implement actual replay logic to mirror the bridge server's replay logic
     if (parsed && parsed.method === "replay") {
       return
     }


### PR DESCRIPTION
## What

Adds an opt-in `pinOrigin` join option (defaults to `true`, fully backward-compatible) that lets a joiner **not** pin the connection-string origin.

## Why

Today a joiner always pins the `d=` origin from the connection string and rejects any connection whose real, server-observed origin differs. That makes it impossible for a consumer to support a QR generated by one origin on behalf of a different domain (e.g. a project's verified `allowedOrigins`), because the channel is refused before the consumer can make a trust decision.

With `pinOrigin: false`, the joiner leaves its expected origin unset, so the existing origin-on-connect (`ooc`) handler **adopts** the real origin the server reports instead of rejecting on mismatch. Trust is then left to the caller.

## Compatibility

Default behavior (`pinOrigin` unset / `true`) is unchanged — existing callers keep pinning and rejecting mismatches. Bumped to `0.12.1`.